### PR TITLE
Implement "Introduce Otter" blog post

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +549,12 @@ dependencies = [
  "serde",
  "throw_error",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1283,6 +1324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1393,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca71fb01735fbc6fa13e9390d7a3037dde97053c0b65c0c72c0159cd009d26b"
 dependencies = [
  "nom",
+ "tailwind_fuse_macro",
+]
+
+[[package]]
+name = "tailwind_fuse_macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa51b9ff80b5533001f8452d254a688bc7bb39c6bb77f9e0a19c1664d035888"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -10,4 +10,4 @@ console_log = "1.0.0"
 leptos = { version = "0.7.3", features = ["csr"] }
 leptos_meta = "0.7.3"
 log = "0.4.22"
-tailwind_fuse = "0.3.2"
+tailwind_fuse = { version = "0.3.2", features = ["variant"] }

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -1,6 +1,8 @@
 use leptos::prelude::*;
 use leptos_meta::*;
 
+use crate::components::*;
+
 #[component]
 pub fn App() -> impl IntoView {
     // Provides context that manages stylesheets, titles, meta tags, etc.
@@ -16,6 +18,113 @@ pub fn App() -> impl IntoView {
         <Meta charset="UTF-8" />
         <Meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <p>"Hello from Otter! 🦦"</p>
+        <div class="container mx-auto max-w-4xl py-8">
+
+            <H1>"Introducing Otter 🦦"</H1>
+
+            <P>
+                "Otter is an opinionated framework for creating modern, cross-platform applications with Rust."
+            </P>
+            <P>
+                "At its core, Otter is guided by a set of convictions about how modern software should be built:"
+            </P>
+
+            <List list_type=ListType::Ordered>
+                <ListItem>
+                    <P>
+                        <strong>"We Believe That There Are Better Ways to Write Code"</strong>
+                    </P>
+                    <P>
+                        "Over decades, the tech industry has developed best practices for creating maintainable, performant, and secure applications. These principles have proven their worth at scale, but they’re often inaccessible to smaller teams. Otter embeds these lessons directly into the framework, empowering developers of all sizes to work smarter and faster."
+                    </P>
+                </ListItem>
+                <ListItem>
+                    <P>
+                        <strong>"We Believe Rust Is a Better Programming Language"</strong>
+                    </P>
+                    <P>
+                        "Rust’s powerful type system provides strong guarantees about code correctness, safety, and reliability, allowing developers to catch most potential errors during development rather than in production."
+                    </P>
+
+                </ListItem>
+                <ListItem>
+                    <P>
+                        <strong>"We Believe Opinionated Frameworks Are Better"</strong>
+                    </P>
+                    <P>
+                        "Opinionated frameworks solve foundational problems once, so developers can focus on what matters most—creating value. By offering clear conventions and a comprehensive toolset, Otter eliminates decision fatigue and accelerates the path from idea to execution."
+                    </P>
+                </ListItem>
+            </List>
+
+            <P>
+                "At the end of the day, building apps shouldn’t require large teams of specialized developers. "
+                <strong>
+                    "With Otter, we’re combining the prototyping speed of Ruby on Rails with the cross-platform reach of Expo."
+                </strong>
+                " Our mission is to empower small teams to build profitable businesses and deliver meaningful applications to their users—wherever they are, on any platform."
+            </P>
+
+            <H2>"Roadmap"</H2>
+            <P>
+                "Building Otter is an ambitious undertaking, and we’re embracing the journey step by step. While the vision is clear, there are still many foundations to lay and challenges to navigate. With that in mind, here’s a rough outline of the roadmap we’ll follow to bring Otter to life."
+            </P>
+
+            <H3>"Web Applications"</H3>
+            <P>
+                "We’ll begin by prototyping Otter’s command-line interface (CLI), focusing initially on client-side rendered web applications. The goal is to provide developers with the tools they need to get started quickly and efficiently. This phase will include:"
+            </P>
+            <List list_type=ListType::Unordered>
+                <ListItem>"Generating a new static website to serve as a starting point."</ListItem>
+                <ListItem>
+                    "Adding generators for a pre-made component library to accelerate UI development."
+                </ListItem>
+                <ListItem>
+                    "Introducing routing and support for building multi-page web applications."
+                </ListItem>
+            </List>
+
+            <H3>"Backend & API"</H3>
+            <P>
+                "Once the web application prototype is stable, the next step is to introduce backend functionality. This includes:"
+            </P>
+            <List list_type=ListType::Unordered>
+                <ListItem>
+                    "Seamless integration with a Postgres database for managing data."
+                </ListItem>
+                <ListItem>
+                    "Support for RESTful APIs to enable communication between the frontend and backend."
+                </ListItem>
+            </List>
+
+            <H2>"Authentication & Authorization"</H2>
+            <P>
+                "Security is a cornerstone of modern applications. During this phase, we’ll add:"
+            </P>
+            <List list_type=ListType::Unordered>
+                <ListItem>"Authentication systems to manage user access."</ListItem>
+                <ListItem>
+                    "Authorization capabilities to ensure users only access the resources they’re permitted to."
+                </ListItem>
+            </List>
+
+            <H2>"Developer Experience and DevOps"</H2>
+            <P>
+                "A great framework is only as good as the developer experience it offers. This phase will focus on:"
+            </P>
+            <List list_type=ListType::Unordered>
+                <ListItem>
+                    "Streamlining the development workflow to make Otter intuitive and enjoyable to use."
+                </ListItem>
+                <ListItem>
+                    "Providing tools and integrations for deployment, testing, and CI/CD pipelines to ensure seamless operations."
+                </ListItem>
+            </List>
+
+            <H2>"Mobile Apps"</H2>
+            <P>
+                "Finally, we’ll enable cross-platform mobile application development with Otter. This phase will unlock the ability to write mobile apps alongside web and backend code, ensuring a unified development experience across all platforms."
+            </P>
+        </div>
     }
 }

--- a/crates/web/src/components/h1.rs
+++ b/crates/web/src/components/h1.rs
@@ -1,0 +1,12 @@
+use leptos::prelude::*;
+use tailwind_fuse::tw_merge;
+
+#[component]
+pub fn H1(#[prop(optional)] class: &'static str, children: Children) -> impl IntoView {
+    let classes = tw_merge!(
+        "scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl",
+        class
+    );
+
+    view! { <h1 class=classes>{children()}</h1> }
+}

--- a/crates/web/src/components/h2.rs
+++ b/crates/web/src/components/h2.rs
@@ -1,0 +1,12 @@
+use leptos::prelude::*;
+use tailwind_fuse::tw_merge;
+
+#[component]
+pub fn H2(#[prop(optional)] class: &'static str, children: Children) -> impl IntoView {
+    let classes = tw_merge!(
+        "mt-10 scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0",
+        class
+    );
+
+    view! { <h2 class=classes>{children()}</h2> }
+}

--- a/crates/web/src/components/h3.rs
+++ b/crates/web/src/components/h3.rs
@@ -1,0 +1,12 @@
+use leptos::prelude::*;
+use tailwind_fuse::tw_merge;
+
+#[component]
+pub fn H3(#[prop(optional)] class: &'static str, children: Children) -> impl IntoView {
+    let classes = tw_merge!(
+        "mt-8 scroll-m-20 text-2xl font-semibold tracking-tight",
+        class
+    );
+
+    view! { <h3 class=classes>{children()}</h3> }
+}

--- a/crates/web/src/components/list.rs
+++ b/crates/web/src/components/list.rs
@@ -1,0 +1,32 @@
+use leptos::either::either;
+use leptos::prelude::*;
+use tailwind_fuse::*;
+
+#[derive(TwClass)]
+#[tw(class = "my-6 ml-6 [&>li]:mt-2")]
+struct ListStyle {
+    list_type: ListType,
+}
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, TwVariant)]
+pub enum ListType {
+    #[tw(default, class = "list-decimal")]
+    Ordered,
+    #[tw(class = "list-disc")]
+    Unordered,
+}
+
+#[component]
+pub fn List(
+    #[prop(optional)] class: &'static str,
+    #[prop(optional)] list_type: ListType,
+    // TODO: Can we limit this to only accept ListItems?
+    children: Children,
+) -> impl IntoView {
+    let final_class = ListStyle { list_type }.with_class(class);
+
+    either!(list_type,
+        ListType::Ordered => view! { <ol class=final_class>{children()}</ol> },
+        _ => view! { <ul class=final_class>{children()}</ul> },
+    )
+}

--- a/crates/web/src/components/list_item.rs
+++ b/crates/web/src/components/list_item.rs
@@ -1,0 +1,6 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn ListItem(#[prop(optional)] class: &'static str, children: Children) -> impl IntoView {
+    view! { <li class=class>{children()}</li> }
+}

--- a/crates/web/src/components/mod.rs
+++ b/crates/web/src/components/mod.rs
@@ -1,0 +1,13 @@
+//! Components library for the project
+mod h1;
+pub use self::h1::*;
+mod p;
+pub use self::p::*;
+mod list;
+pub use self::list::*;
+mod list_item;
+pub use self::list_item::*;
+mod h2;
+pub use self::h2::*;
+mod h3;
+pub use self::h3::*;

--- a/crates/web/src/components/p.rs
+++ b/crates/web/src/components/p.rs
@@ -1,0 +1,9 @@
+use leptos::prelude::*;
+use tailwind_fuse::tw_merge;
+
+#[component]
+pub fn P(#[prop(optional)] class: &'static str, children: Children) -> impl IntoView {
+    let classes = tw_merge!("leading-7 [&:not(:first-child)]:mt-6", class);
+
+    view! { <p class=classes>{children()}</p> }
+}

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -3,6 +3,7 @@ use leptos::prelude::*;
 use crate::app::App;
 
 mod app;
+mod components;
 
 fn main() {
     // Set up logging


### PR DESCRIPTION
The default app has been replaced with a blog post that introduces the Otter framework. The components used in the blog post have been generated using a development version of the `otter` CLI.